### PR TITLE
✨ Feat: 면접 선택 화면 구성

### DIFF
--- a/Hello-iOS/App/SceneDelegate.swift
+++ b/Hello-iOS/App/SceneDelegate.swift
@@ -54,9 +54,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 extension SceneDelegate {
   func makeTabBarController() -> UITabBarController {
     let container = DIContainer.shared
-    container.register(ViewController(reactor: ViewReactor()))
+    container.register(InterviewViewController(reactor: InterviewReactor()))
 
-    let interviewVC: ViewController = container.resolve()
+    let interviewVC: InterviewViewController = container.resolve()
     let myPageVC = UIViewController()
     let wordBookVC = UIViewController()
     let tabBarController = UITabBarController()

--- a/Hello-iOS/Presentation/CommonViews/ShadiwButton.swift
+++ b/Hello-iOS/Presentation/CommonViews/ShadiwButton.swift
@@ -1,0 +1,47 @@
+//
+//  ShadiwButton.swift
+//  Hello-iOS
+//
+//  Created by 이태윤 on 8/7/25.
+//
+import UIKit
+
+class ShadowButton: UIButton {
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupStyle()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setupStyle()
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    applyShadow()
+  }
+
+  private func setupStyle() {
+    layer.cornerRadius = 15
+    backgroundColor = .systemBackground
+    setTitleColor(.label, for: .normal)
+    tintColor = .label
+    titleLabel?.font = .systemFont(ofSize: 25, weight: .bold)
+    layer.borderWidth = 1
+    layer.borderColor = UIColor.black.cgColor
+    clipsToBounds = false
+  }
+
+  private func applyShadow() {
+    layer.shadowColor = UIColor.black.cgColor
+    layer.shadowOpacity = 0.2
+    layer.shadowOffset = CGSize(width: 0, height: 2)
+    layer.shadowRadius = 4
+    layer.shadowPath = UIBezierPath(
+      roundedRect: bounds,
+      cornerRadius: layer.cornerRadius
+    ).cgPath
+  }
+}

--- a/Hello-iOS/Presentation/Interview/InterviewReactor.swift
+++ b/Hello-iOS/Presentation/Interview/InterviewReactor.swift
@@ -1,5 +1,5 @@
 //
-//  ViewReactor.swift
+//  InterviewReactor.swift
 //  Hello-iOS
 //
 //  Created by 이태윤 on 8/6/25.
@@ -7,10 +7,10 @@
 import ReactorKit
 import RxSwift
 
-final class ViewReactor: BaseReactor<
-ViewReactor.Action,
-ViewReactor.Mutation,
-ViewReactor.State
+final class InterviewReactor: BaseReactor<
+InterviewReactor.Action,
+InterviewReactor.Mutation,
+InterviewReactor.State
 > {
   // 사용자 액션 정의 (사용자의 의도)
   enum Action {}

--- a/Hello-iOS/Presentation/Interview/InterviewViewController.swift
+++ b/Hello-iOS/Presentation/Interview/InterviewViewController.swift
@@ -31,7 +31,7 @@ class InterviewViewController: BaseViewController<InterviewReactor> {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    setUI()
+    setupUI()
     setConstraints()
   }
 
@@ -45,7 +45,7 @@ class InterviewViewController: BaseViewController<InterviewReactor> {
   }
 
   // UI 추가
-  private func setUI() {
+  override func setupUI() {
     view.addSubview(buttonStackView)
     buttonStackView.addArrangedSubview(myStudyInterviewButton)
     buttonStackView.addArrangedSubview(reviewInterviewButton)

--- a/Hello-iOS/Presentation/Interview/InterviewViewController.swift
+++ b/Hello-iOS/Presentation/Interview/InterviewViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  InterViewController.swift
 //  Hello-iOS
 //
 //  Created by 이태윤 on 8/6/25.
@@ -10,14 +10,14 @@ import ReactorKit
 import Then
 import SnapKit
 
-class ViewController: BaseViewController<ViewReactor> {
+class InterviewViewController: BaseViewController<InterviewReactor> {
 
   override func viewDidLoad() {
     super.viewDidLoad()
     print("hello world")
     view.backgroundColor = .blue
   }
-  init(reactor: ViewReactor) {
+  init(reactor: InterviewReactor) {
     super.init(nibName: nil, bundle: nil)
     self.reactor = reactor
   }

--- a/Hello-iOS/Presentation/Interview/InterviewViewController.swift
+++ b/Hello-iOS/Presentation/Interview/InterviewViewController.swift
@@ -12,45 +12,27 @@ import SnapKit
 
 class InterviewViewController: BaseViewController<InterviewReactor> {
 
-  let myStudyInterviewButton = UIButton(type: .system).then {
-    $0.setTitle("내 학습 기반 모의 면접", for: .normal)
-    $0.backgroundColor = .systemBackground
-    $0.layer.cornerRadius = 8
-    $0.tintColor = .label
-    $0.titleLabel?.font = .systemFont(ofSize: 25, weight: .bold)
-    $0.layer.shadowColor = UIColor.black.cgColor
-    $0.layer.shadowOpacity = 0.2
-    $0.layer.shadowOffset = CGSize(width: 0, height: 2)
-    $0.layer.shadowRadius = 4
+  let buttonStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 24
+    $0.alignment = .fill
+    $0.distribution = .fillEqually
+    $0.clipsToBounds = false
+    $0.layer.masksToBounds = false
   }
 
-  let reviewInterviewButton = UIButton(type: .system).then {
+  let myStudyInterviewButton = ShadowButton().then {
+    $0.setTitle("내 학습 기반 모의 면접", for: .normal)
+  }
+
+  let reviewInterviewButton = ShadowButton().then {
     $0.setTitle("복습 모의 면접", for: .normal)
-    $0.backgroundColor = .systemBackground
-    $0.layer.cornerRadius = 8
-    $0.tintColor = .label
-    $0.titleLabel?.font = .systemFont(ofSize: 25, weight: .bold)
-    $0.layer.shadowColor = UIColor.black.cgColor
-    $0.layer.shadowOpacity = 0.2
-    $0.layer.shadowOffset = CGSize(width: 0, height: 2)
-    $0.layer.shadowRadius = 4
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
     setUI()
     setConstraints()
-  }
-
-  override func viewDidLayoutSubviews() {
-    super.viewDidLayoutSubviews()
-    myStudyInterviewButton.layer.shadowPath = UIBezierPath(
-      roundedRect: myStudyInterviewButton.bounds,
-      cornerRadius: myStudyInterviewButton.layer.cornerRadius).cgPath
-
-    reviewInterviewButton.layer.shadowPath = UIBezierPath(
-      roundedRect: reviewInterviewButton.bounds,
-      cornerRadius: reviewInterviewButton.layer.cornerRadius).cgPath
   }
 
   init(reactor: InterviewReactor) {
@@ -64,23 +46,16 @@ class InterviewViewController: BaseViewController<InterviewReactor> {
 
   // UI 추가
   private func setUI() {
-    view.addSubview(myStudyInterviewButton)
-    view.addSubview(reviewInterviewButton)
+    view.addSubview(buttonStackView)
+    buttonStackView.addArrangedSubview(myStudyInterviewButton)
+    buttonStackView.addArrangedSubview(reviewInterviewButton)
   }
 
   //  레이아웃 설정
   private func setConstraints() {
-    myStudyInterviewButton.snp.makeConstraints {
-      $0.center.equalToSuperview()
-      $0.leading.trailing.equalToSuperview().inset(16)
-      $0.width.equalTo(350)
-    }
-
-    reviewInterviewButton.snp.makeConstraints {
-      $0.top.equalTo(myStudyInterviewButton.snp.bottom).offset(15)
-      $0.centerX.equalToSuperview()
-      $0.leading.trailing.equalToSuperview().inset(16)
-      $0.width.equalTo(350)
+    buttonStackView.snp.makeConstraints {
+      $0.directionalEdges.equalTo(view.safeAreaLayoutGuide).inset(16)
     }
   }
 }
+

--- a/Hello-iOS/Presentation/Interview/InterviewViewController.swift
+++ b/Hello-iOS/Presentation/Interview/InterviewViewController.swift
@@ -12,11 +12,47 @@ import SnapKit
 
 class InterviewViewController: BaseViewController<InterviewReactor> {
 
+  let myStudyInterviewButton = UIButton(type: .system).then {
+    $0.setTitle("내 학습 기반 모의 면접", for: .normal)
+    $0.backgroundColor = .systemBackground
+    $0.layer.cornerRadius = 8
+    $0.tintColor = .label
+    $0.titleLabel?.font = .systemFont(ofSize: 25, weight: .bold)
+    $0.layer.shadowColor = UIColor.black.cgColor
+    $0.layer.shadowOpacity = 0.2
+    $0.layer.shadowOffset = CGSize(width: 0, height: 2)
+    $0.layer.shadowRadius = 4
+  }
+
+  let reviewInterviewButton = UIButton(type: .system).then {
+    $0.setTitle("복습 모의 면접", for: .normal)
+    $0.backgroundColor = .systemBackground
+    $0.layer.cornerRadius = 8
+    $0.tintColor = .label
+    $0.titleLabel?.font = .systemFont(ofSize: 25, weight: .bold)
+    $0.layer.shadowColor = UIColor.black.cgColor
+    $0.layer.shadowOpacity = 0.2
+    $0.layer.shadowOffset = CGSize(width: 0, height: 2)
+    $0.layer.shadowRadius = 4
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
-    print("hello world")
-    view.backgroundColor = .blue
+    setUI()
+    setConstraints()
   }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    myStudyInterviewButton.layer.shadowPath = UIBezierPath(
+      roundedRect: myStudyInterviewButton.bounds,
+      cornerRadius: myStudyInterviewButton.layer.cornerRadius).cgPath
+
+    reviewInterviewButton.layer.shadowPath = UIBezierPath(
+      roundedRect: reviewInterviewButton.bounds,
+      cornerRadius: reviewInterviewButton.layer.cornerRadius).cgPath
+  }
+
   init(reactor: InterviewReactor) {
     super.init(nibName: nil, bundle: nil)
     self.reactor = reactor
@@ -24,5 +60,27 @@ class InterviewViewController: BaseViewController<InterviewReactor> {
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  // UI 추가
+  private func setUI() {
+    view.addSubview(myStudyInterviewButton)
+    view.addSubview(reviewInterviewButton)
+  }
+
+  //  레이아웃 설정
+  private func setConstraints() {
+    myStudyInterviewButton.snp.makeConstraints {
+      $0.center.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(16)
+      $0.width.equalTo(350)
+    }
+
+    reviewInterviewButton.snp.makeConstraints {
+      $0.top.equalTo(myStudyInterviewButton.snp.bottom).offset(15)
+      $0.centerX.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(16)
+      $0.width.equalTo(350)
+    }
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #15 

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 면접 선택 버튼 두개를 배치하고 위에 내 학습 기반 모의 면접을 누르면 사용자가 등록한 카테고리 리스트가 나오고 그 안에서 외운 개념들 중 랜덤으로 10개를 선택해서 모의 면접을 보고 그아래 복습 모의 면접을 누르면 면접 기록에서 불만족 했던 것들 중에 랜덤으로 10 개 모의 면접을 보게끔 기능을 추가하겠습니다.
- CommonViews를 추가해서 공통으로 사용 할 수 있는 그림자가 적용되어있는 버튼을 만들 수 있게 ShadiwButton.swift를 추가했습니다. 

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-07 at 10 51 44" src="https://github.com/user-attachments/assets/5f577aa5-27da-443b-b728-2883f059a178" />


## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.

추 후 디자인 변경할 수 있습니다! 일단 기초 디자인 틀을 잡아 놓았습니다.
