### PR TITLE
Feat/#21 단어장 화면 UI 구현

### DIFF
--- a/Hello-iOS/App/SceneDelegate.swift
+++ b/Hello-iOS/App/SceneDelegate.swift
@@ -64,9 +64,6 @@ extension SceneDelegate {
     
     let interviewVC: InterviewViewController = container.resolve()
     let myPageVC: MyPageInfoViewController = container.resolve()
-    
-    let wordBookVC = UIViewController()
-    let myPageVC = UIViewController()
     let wordBookVC: WordBookViewController = container.resolve()
     let tabBarController = UITabBarController()
 

--- a/Hello-iOS/App/SceneDelegate.swift
+++ b/Hello-iOS/App/SceneDelegate.swift
@@ -55,10 +55,11 @@ extension SceneDelegate {
   func makeTabBarController() -> UITabBarController {
     let container = DIContainer.shared
     container.register(InterviewViewController(reactor: InterviewReactor()))
+    container.register(WordBookViewController())
 
     let interviewVC: InterviewViewController = container.resolve()
     let myPageVC = UIViewController()
-    let wordBookVC = UIViewController()
+    let wordBookVC: WordBookViewController = container.resolve()
     let tabBarController = UITabBarController()
 
     wordBookVC.tabBarItem = UITabBarItem(
@@ -91,6 +92,17 @@ extension SceneDelegate {
     appearance.shadowColor = .lightGray
     tabBarController.tabBar.standardAppearance = appearance
     tabBarController.tabBar.scrollEdgeAppearance = tabBarController.tabBar.standardAppearance
+
+    /// 상단 네비게이션의 경계션 표현
+    let topAppearance = UINavigationBarAppearance()
+
+    topAppearance.configureWithOpaqueBackground()
+    topAppearance.backgroundColor = .background
+    topAppearance.titleTextAttributes = [.foregroundColor: UIColor.label]
+    topAppearance.shadowColor = UIColor.lightGray
+
+    UINavigationBar.appearance().standardAppearance = topAppearance
+    UINavigationBar.appearance().scrollEdgeAppearance = topAppearance
 
     return tabBarController
   }

--- a/Hello-iOS/Model/MockWordBook.swift
+++ b/Hello-iOS/Model/MockWordBook.swift
@@ -1,0 +1,23 @@
+//
+//  MockWordBook.swift
+//  Hello-iOS
+//
+//  Created by seongjun cho on 8/7/25.
+//
+
+import Foundation
+
+struct MockWordBook: Hashable {
+  let category: String
+  let id: Int
+  let concepts: [MockConcept]
+}
+
+struct MockConcept: Hashable {
+  let id: Int
+  let categoryId: Int
+  let concept: String
+  let explain: String
+  let latestUpdate: Date
+  let isMemory: Bool
+}

--- a/Hello-iOS/Presentation/WordBook/WordBookCell.swift
+++ b/Hello-iOS/Presentation/WordBook/WordBookCell.swift
@@ -1,0 +1,82 @@
+//
+//  WordBookCell.swift
+//  Hello-iOS
+//
+//  Created by seongjun cho on 8/7/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class WordBookCell: UICollectionViewCell {
+  let identifier: String = "WordBookCell"
+
+  private let titleLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 28, weight: .bold)
+  }
+
+  private let progressLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 16, weight: .bold)
+  }
+
+  private let progressView = UIProgressView(progressViewStyle: .bar).then {
+    $0.progressTintColor = .main
+    $0.layer.cornerRadius = 2
+    $0.layer.masksToBounds = true
+    $0.backgroundColor = .secondarySystemFill
+  }
+
+  private let verticalStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.spacing = 12
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    addSubview(verticalStackView)
+    verticalStackView.addArrangedSubview(titleLabel)
+    verticalStackView.addArrangedSubview(progressLabel)
+    verticalStackView.addArrangedSubview(progressView)
+
+    progressView.snp.makeConstraints {
+      $0.height.equalTo(5)
+    }
+
+    progressLabel.snp.makeConstraints {
+      $0.height.equalTo(progressLabel.font.lineHeight)
+    }
+
+    titleLabel.snp.makeConstraints {
+      $0.height.equalTo(titleLabel.font.lineHeight)
+    }
+
+    verticalStackView.snp.makeConstraints {
+      $0.top.leading.trailing.bottom.equalToSuperview().inset(16)
+    }
+
+    self.backgroundColor = .card
+    self.layer.cornerRadius = 20
+    self.layer.shadowColor = UIColor.black.cgColor
+    self.layer.shadowOffset = CGSize(width: 0, height: 4)
+    self.layer.shadowRadius = 3
+    self.layer.shadowOpacity = 0.35
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.shadowPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: self.layer.cornerRadius).cgPath
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configure(title: String, memorized: Int, total: Int) {
+    titleLabel.text = title
+    progressLabel.text = "\(memorized)/\(total) [\(Int(Float(memorized) / Float(total) * 100))%]"
+    progressView.progress = Float(memorized) / Float(total)
+  }
+}

--- a/Hello-iOS/Presentation/WordBook/WordBookReactor.swift
+++ b/Hello-iOS/Presentation/WordBook/WordBookReactor.swift
@@ -1,0 +1,23 @@
+//
+//  WordBookReactor.swift
+//  Hello-iOS
+//
+//  Created by seongjun cho on 8/7/25.
+//
+
+import Foundation
+
+import ReactorKit
+
+class WordBookReactor: BaseReactor<
+WordBookReactor.Action,
+WordBookReactor.Mutation,
+WordBookReactor.State
+> {
+
+  enum Action {}
+
+  enum Mutation {}
+
+  struct State {}
+}

--- a/Hello-iOS/Presentation/WordBook/WordBookView.swift
+++ b/Hello-iOS/Presentation/WordBook/WordBookView.swift
@@ -1,0 +1,58 @@
+//
+//  WordBookView.swift
+//  Hello-iOS
+//
+//  Created by seongjun cho on 8/7/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class WordBookView: UIView {
+
+  lazy var collectionView = UICollectionView(
+    frame: .zero,
+    collectionViewLayout: makeCollectionViewLayout()).then {
+    $0.showsVerticalScrollIndicator = false
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setupUI() {
+    addSubview(collectionView)
+
+    collectionView.snp.makeConstraints {
+      $0.top.leading.trailing.bottom.equalTo(self.safeAreaLayoutGuide)
+    }
+  }
+
+  private func makeCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+    return UICollectionViewCompositionalLayout { (sectionIndex, env) -> NSCollectionLayoutSection? in
+
+      let item = NSCollectionLayoutItem(
+        layoutSize: .init(widthDimension: .fractionalWidth(1.0),
+                          heightDimension: .fractionalHeight(1.0)))
+
+      let group = NSCollectionLayoutGroup.vertical(
+        layoutSize: .init(widthDimension: .fractionalWidth(1.0),
+                          heightDimension: .absolute(106)),
+        subitems: [item])
+
+      let section = NSCollectionLayoutSection(group: group)
+      section.interGroupSpacing = 8
+      section.contentInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+
+      return section
+    }
+  }
+}

--- a/Hello-iOS/Presentation/WordBook/WordBookViewController.swift
+++ b/Hello-iOS/Presentation/WordBook/WordBookViewController.swift
@@ -1,0 +1,95 @@
+//
+//  WordBookViewController.swift
+//  Hello-iOS
+//
+//  Created by seongjun cho on 8/7/25.
+//
+
+import UIKit
+
+class WordBookViewController: BaseViewController<WordBookReactor> {
+
+  private let wordBookView = WordBookView()
+  private lazy var dataSource = makeCollectionViewDataSource(wordBookView.collectionView)
+
+  override func loadView() {
+    self.view = wordBookView
+  }
+
+  override func viewDidLoad() {
+    self.navigationItem.title = "단어장"
+
+//    let mockConcepts = MockConcept(
+//      id: 1,
+//      categoryId: 1,
+//      concept: "MVVM",
+//      explain: "대충 MVVM에 대한 설명",
+//      latestUpdate: Date(),
+//      isMemory: true
+//    )
+//
+//    let mockConcepts2 = MockConcept(
+//      id: 2,
+//      categoryId: 1,
+//      concept: "MVVM",
+//      explain: "대충 MVVM에 대한 설명",
+//      latestUpdate: Date(),
+//      isMemory: false
+//    )
+//
+//    let mockData1 = MockWordBook(
+//      category: "디자인 패턴",
+//      id: 1,
+//      concepts: [mockConcepts, mockConcepts2]
+//    )
+//    let mockData2 = MockWordBook(category: "디자인 패턴", id: 2, concepts: [mockConcepts])
+//    let mockData3 = MockWordBook(category: "디자인 패턴", id: 3, concepts: [mockConcepts])
+//    let mockData4 = MockWordBook(category: "디자인 패턴", id: 4, concepts: [mockConcepts])
+//    let mockData5 = MockWordBook(category: "디자인 패턴", id: 5, concepts: [mockConcepts])
+//    let mockData6 = MockWordBook(category: "디자인 패턴", id: 6, concepts: [mockConcepts])
+//
+//    dataApply(data: [mockData1,
+//                     mockData2,
+//                     mockData3,
+//                     mockData4,
+//                     mockData5,
+//                     mockData6
+//                    ])
+  }
+
+  private func dataApply(data: [MockWordBook]) {
+    var snapshot = NSDiffableDataSourceSnapshot<Int, MockWordBook>()
+
+    snapshot.appendSections([0])
+    snapshot.appendItems(data, toSection: 0)
+
+    dataSource.apply(snapshot, animatingDifferences: true)
+  }
+
+  private func makeCollectionViewDataSource(
+    _ collectionView: UICollectionView) -> UICollectionViewDiffableDataSource<Int, MockWordBook> {
+
+      // 셀 설정
+      let cellRegistration = UICollectionView.CellRegistration<WordBookCell, MockWordBook> { cell, _, item in
+        cell.configure(title: item.category,
+                       memorized: item.concepts
+                                      .map { $0.isMemory }
+                                      .filter { $0 }.count,
+                       total: item.concepts.count)
+      }
+
+      // 아이템별 데이터 소스 등록
+      let dataSource = UICollectionViewDiffableDataSource<Int, MockWordBook>(
+        collectionView: collectionView) { collectionView, indexPath, item in
+          return collectionView
+            .dequeueConfiguredReusableCell(
+              using: cellRegistration,
+              for: indexPath,
+              item: item
+            )
+
+      }
+
+      return dataSource
+    }
+}

--- a/Hello-iOS/Services/LearningService.swift
+++ b/Hello-iOS/Services/LearningService.swift
@@ -7,7 +7,15 @@
 
 import Foundation
 
-class LearningService {
+protocol LearningServiceProtocol {
+  func requestAllData() async throws -> [Categories]
+
+  func requestRecentlyData() async throws -> [Concept]
+
+  func setLatestUpdateTimeNow()
+}
+
+class LearningService: LearningServiceProtocol {
   private let learningRepository: LearningRepository
 
   init(learningRepository: LearningRepository) {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #21

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 단어장 화면 UI 를 구성했습니다.
- 일단 데이터 모델은 mock으로 만들어서 사용했습니다.

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.
<img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 13 24 27" src="https://github.com/user-attachments/assets/18502ee2-fe67-4043-97ba-9d076f1a244f" />


## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.

단어 데이터를 넣어야 하는부분은 일단은 직접 주입하고 주석처리하였습니다.