### PR TITLE
Feat/#38 RealmService 추가

### DIFF
--- a/Hello-iOS/Services/RealmService.swift
+++ b/Hello-iOS/Services/RealmService.swift
@@ -10,23 +10,23 @@ protocol RealmServiceType {
   // 트랜잭션
   func write(_ block: (Realm) throws -> Void) throws
   func writeAsync(_ block: @escaping (Realm) throws -> Void)
-
+  
   // Create
   func insert<T: Object>(_ object: T) throws
   func insert<T: Object>(_ objects: [T]) throws
-
+  
   // Read
   func fetch<T: Object>(_ type: T.Type,
                         predicate: NSPredicate?,
                         sorted: [RealmSwift.SortDescriptor]) throws -> Results<T>
   func find<T: Object>(_ type: T.Type, forPrimaryKey key: Any) throws -> T?
-
+  
   // Update
   /// PK가 있는 타입을 PK로 찾아 업데이트
   func update<T: Object>(_ type: T.Type, forPrimaryKey key: Any, _ apply: (T) -> Void) throws
   /// PK가 없거나 일괄 수정이 필요할 때 predicate로 찾아 업데이트
   func updateAll<T: Object>(_ type: T.Type, predicate: NSPredicate, _ apply: (T) -> Void) throws
-
+  
   // Delete
   func delete<T: Object>(_ object: T) throws
   func deleteAll<T: Object>(_ type: T.Type, predicate: NSPredicate?) throws
@@ -35,17 +35,17 @@ protocol RealmServiceType {
 final class RealmService: RealmServiceType {
   private let config: Realm.Configuration
   private let bgQueue = DispatchQueue(label: "realm.bg.queue")
-
+  
   init(config: Realm.Configuration = .defaultConfiguration) {
     self.config = config
   }
-
+  
   // MARK: - Write
   func write(_ block: (Realm) throws -> Void) throws {
     let realm = try Realm(configuration: config)
     try realm.write { try block(realm) }
   }
-
+  
   func writeAsync(_ block: @escaping (Realm) throws -> Void) {
     bgQueue.async {
       autoreleasepool {
@@ -53,23 +53,23 @@ final class RealmService: RealmServiceType {
           let realm = try Realm(configuration: self.config)
           try realm.write { try block(realm) }
         } catch {
-          #if DEBUG
+#if DEBUG
           print("Realm writeAsync error:", error)
-          #endif
+#endif
         }
       }
     }
   }
-
+  
   // MARK: - Create
   func insert<T: Object>(_ object: T) throws {
     try write { $0.add(object, update: .error) } // 중복 PK 존재 시 throw
   }
-
+  
   func insert<T: Object>(_ objects: [T]) throws {
     try write { $0.add(objects, update: .error) } // 중복 PK 존재 시 throw
   }
-
+  
   // MARK: - Read
   func fetch<T: Object>(_ type: T.Type,
                         predicate: NSPredicate? = nil,
@@ -80,12 +80,12 @@ final class RealmService: RealmServiceType {
     if !sorted.isEmpty { results = results.sorted(by: sorted) }
     return results
   }
-
+  
   func find<T: Object>(_ type: T.Type, forPrimaryKey key: Any) throws -> T? {
     let realm = try Realm(configuration: config)
     return realm.object(ofType: type, forPrimaryKey: key)
   }
-
+  
   // MARK: - Update
   func update<T: Object>(_ type: T.Type, forPrimaryKey key: Any, _ apply: (T) -> Void) throws {
     let realm = try Realm(configuration: config)
@@ -94,19 +94,19 @@ final class RealmService: RealmServiceType {
     }
     try realm.write { apply(obj) }
   }
-
+  
   func updateAll<T: Object>(_ type: T.Type, predicate: NSPredicate, _ apply: (T) -> Void) throws {
     let realm = try Realm(configuration: config)
     let targets = realm.objects(type).filter(predicate)
     guard !targets.isEmpty else { throw RealmServiceError.objectNotFound }
     try realm.write { targets.forEach(apply) }
   }
-
+  
   // MARK: - Delete
   func delete<T: Object>(_ object: T) throws {
     try write { $0.delete(object) }
   }
-
+  
   func deleteAll<T: Object>(_ type: T.Type, predicate: NSPredicate? = nil) throws {
     try write { realm in
       var targets = realm.objects(type)

--- a/Hello-iOS/Services/RealmService.swift
+++ b/Hello-iOS/Services/RealmService.swift
@@ -1,0 +1,100 @@
+// RealmService.swift
+import Foundation
+import RealmSwift
+
+protocol RealmServiceType {
+  // 트랜잭션
+  func write(_ block: (Realm) throws -> Void) throws
+  func writeAsync(_ block: @escaping (Realm) throws -> Void)
+
+  // Upsert
+  func upsert<T: Object>(_ object: T) throws
+  func upsert<T: Object>(_ objects: [T]) throws
+
+  // Read
+  func fetch<T: Object>(_ type: T.Type,
+                        predicate: NSPredicate?,
+                        sorted: [RealmSwift.SortDescriptor]) throws -> Results<T>
+  func find<T: Object>(_ type: T.Type, forPrimaryKey key: Any) throws -> T?
+
+  // Delete
+  func delete<T: Object>(_ object: T) throws
+  func deleteAll<T: Object>(_ type: T.Type, predicate: NSPredicate?) throws
+}
+
+final class RealmService: RealmServiceType {
+  private let config: Realm.Configuration
+  private let bgQueue = DispatchQueue(label: "realm.bg.queue")
+
+  init(config: Realm.Configuration = .defaultConfiguration) {
+    self.config = config
+  }
+
+  // MARK: - Write
+
+  func write(_ block: (Realm) throws -> Void) throws {
+    let realm = try Realm(configuration: config)
+    do {
+      try realm.write { try block(realm) }
+    } catch {
+      throw error
+    }
+  }
+
+  func writeAsync(_ block: @escaping (Realm) throws -> Void) {
+    bgQueue.async {
+      autoreleasepool {
+        do {
+          let realm = try Realm(configuration: self.config)
+          try realm.write { try block(realm) }
+        } catch {
+          // 필요하면 로깅/콜백
+          #if DEBUG
+          print("Realm writeAsync error:", error)
+          #endif
+        }
+      }
+    }
+  }
+
+  // MARK: - Upsert
+
+  func upsert<T: Object>(_ object: T) throws {
+    try write { $0.add(object, update: .modified) }
+  }
+
+  func upsert<T: Object>(_ objects: [T]) throws {
+    try write { $0.add(objects, update: .modified) }
+  }
+
+  // MARK: - Read
+
+  func fetch<T: Object>(_ type: T.Type,
+                        predicate: NSPredicate? = nil,
+                        sorted: [RealmSwift.SortDescriptor] = []) throws -> Results<T> {
+    let realm = try Realm(configuration: config)
+    var results = realm.objects(type)
+    if let predicate { results = results.filter(predicate) }
+    if !sorted.isEmpty { results = results.sorted(by: sorted) }
+    return results
+  }
+
+  func find<T: Object>(_ type: T.Type, forPrimaryKey key: Any) throws -> T? {
+    let realm = try Realm(configuration: config)
+    return realm.object(ofType: type, forPrimaryKey: key)
+  }
+
+  // MARK: - Delete
+
+  func delete<T: Object>(_ object: T) throws {
+    try write { $0.delete(object) }
+  }
+
+  func deleteAll<T: Object>(_ type: T.Type, predicate: NSPredicate? = nil) throws {
+    try write { realm in
+      var targets = realm.objects(type)
+      if let predicate { targets = targets.filter(predicate) }
+      realm.delete(targets)
+    }
+  }
+}

--- a/Hello-iOSTests/Hello_iOSTests.swift
+++ b/Hello-iOSTests/Hello_iOSTests.swift
@@ -13,17 +13,17 @@ import Foundation
 
 struct Hello_iOSTests {
 
-  @Test func fetchLearningAllData() async throws {
-    let repo = LearningRepository()
-    let result = try await LearningService(learningRepository: repo).requestAllData()
-
-    print(result)
-  }
-
-  @Test func fetchLearningRecentlyData() async throws {
-    let repo = LearningRepository()
-    let result = try await LearningService(learningRepository: repo).requestRecentlyData()
-
-    print(result)
-  }
+//  @Test func fetchLearningAllData() async throws {
+//    let repo = LearningRepository()
+//    let result = try await LearningService(learningRepository: repo).requestAllData()
+//
+//    print(result)
+//  }
+//
+//  @Test func fetchLearningRecentlyData() async throws {
+//    let repo = LearningRepository()
+//    let result = try await LearningService(learningRepository: repo).requestRecentlyData()
+//
+//    print(result)
+//  }
 }

--- a/Hello-iOSTests/Hello_iOSTests.swift
+++ b/Hello-iOSTests/Hello_iOSTests.swift
@@ -13,17 +13,17 @@ import Foundation
 
 struct Hello_iOSTests {
 
-//  @Test func fetchLearningAllData() async throws {
-//    let repo = LearningRepository()
-//    let result = try await LearningService(learningRepository: repo).requestAllData()
-//
-//    print(result)
-//  }
-//
-//  @Test func fetchLearningRecentlyData() async throws {
-//    let repo = LearningRepository()
-//    let result = try await LearningService(learningRepository: repo).requestRecentlyData()
-//
-//    print(result)
-//  }
+  @Test func fetchLearningAllData() async throws {
+    let repo = LearningRepository()
+    let result = try await LearningService(learningRepository: repo).requestAllData()
+
+    print(result)
+  }
+
+  @Test func fetchLearningRecentlyData() async throws {
+    let repo = LearningRepository()
+    let result = try await LearningService(learningRepository: repo).requestRecentlyData()
+
+    print(result)
+  }
 }

--- a/Hello-iOSTests/RealmServiceTest.swift
+++ b/Hello-iOSTests/RealmServiceTest.swift
@@ -1,0 +1,268 @@
+import Foundation
+import RealmSwift
+import Testing
+
+@testable import Hello_iOS // 모듈명에 맞게 교체하세요
+
+// MARK: - Test Helpers
+
+func makeService() -> RealmService {
+  let cfg = Realm.Configuration(inMemoryIdentifier: "Test-\(UUID().uuidString)")
+  return RealmService(config: cfg)
+}
+
+// MARK: - Attendance (PK: id[String])
+
+@Suite("RealmService.Attendance")
+struct AttendanceTests {
+  @Test
+  func insert_and_fetch() throws {
+    let sut = makeService()
+    let att = RealmAttendance()
+    att.id = "A1"
+    att.date = Date()
+    att.isAttendance = true
+    
+    try sut.insert(att)
+    
+    let fetched: Results<RealmAttendance> = try sut.fetch(RealmAttendance.self)
+    #expect(fetched.count == 1)
+    #expect(fetched.first?.id == "A1")
+    #expect(fetched.first?.isAttendance == true)
+  }
+  
+  @Test
+  func insert_duplicate_should_throw() throws {
+    let sut = makeService()
+    
+    let a1 = RealmAttendance(); a1.id = "DUP"; a1.date = Date(); a1.isAttendance = true
+    let a2 = RealmAttendance(); a2.id = "DUP"; a2.date = Date(); a2.isAttendance = false
+    
+    try sut.insert(a1)
+    
+    do {
+      try sut.insert(a2) // 같은 PK
+      Issue.record("Expected duplicate PK error, but insert succeeded.")
+      #expect(false)
+    } catch {
+      // OK: 중복 PK 시 Realm이 throw
+      #expect(true)
+    }
+  }
+  
+  @Test
+  func update_by_primary_key() throws {
+    let sut = makeService()
+    let a = RealmAttendance(); a.id = "U1"; a.date = Date(); a.isAttendance = false
+    try sut.insert(a)
+    
+    try sut.update(RealmAttendance.self, forPrimaryKey: "U1") { obj in
+      obj.isAttendance = true
+    }
+    
+    let got = try sut.find(RealmAttendance.self, forPrimaryKey: "U1")
+    #expect(got?.isAttendance == true)
+  }
+  
+  @Test
+  func update_missing_should_throw_objectNotFound() throws {
+    let sut = makeService()
+    do {
+      try sut.update(RealmAttendance.self, forPrimaryKey: "NOPE") { _ in }
+      Issue.record("Expected objectNotFound, but update succeeded.")
+      #expect(false)
+    } catch let e as RealmServiceError {
+      #expect(e == .objectNotFound)
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+      #expect(false)
+    }
+  }
+  
+  @Test
+  func delete_single_and_bulk() throws {
+    let sut = makeService()
+    let a1 = RealmAttendance(); a1.id = "D1"; a1.date = Date(); a1.isAttendance = true
+    let a2 = RealmAttendance(); a2.id = "D2"; a2.date = Date(); a2.isAttendance = false
+    try sut.insert([a1, a2])
+    
+    // 단건 삭제
+    if let target = try sut.find(RealmAttendance.self, forPrimaryKey: "D1") {
+      try sut.delete(target)
+    }
+    #expect((try sut.fetch(RealmAttendance.self)).count == 1)
+    
+    // 벌크 삭제(조건)
+    let p = NSPredicate(format: "isAttendance == %@", NSNumber(booleanLiteral: false))
+    try sut.deleteAll(RealmAttendance.self, predicate: p)
+    #expect((try sut.fetch(RealmAttendance.self)).count == 0)
+  }
+}
+
+// MARK: - MockInterview Group & Record (Group PK: id[String], Record: no PK)
+
+@Suite("RealmService.MockInterview")
+struct MockInterviewTests {
+  @Test
+  func create_group_and_append_record() throws {
+    let sut = makeService()
+    
+    // 그룹 생성
+    let g = RealmMockInterviewGroup()
+    g.id = "G-1"
+    g.date = Date()
+    try sut.insert(g)
+    
+    // 레코드 추가 (그룹 내부 List에 append)
+    try sut.update(RealmMockInterviewGroup.self, forPrimaryKey: "G-1") { group in
+      let r = RealmMockInterviewRecord()
+      r.id = 0
+      r.groupId = group.id
+      r.question = "Q1"
+      r.modelAnswer = "A1"
+      r.myAnswer = "B1"
+      r.isSatisfied = false
+      group.records.append(r)
+    }
+    
+    let got = try sut.find(RealmMockInterviewGroup.self, forPrimaryKey: "G-1")
+    #expect(got?.records.count == 1)
+    #expect(got?.records.first?.question == "Q1")
+  }
+  
+  @Test
+  func toggle_record_satisfaction() throws {
+    let sut = makeService()
+    
+    let g = RealmMockInterviewGroup()
+    g.id = "G-2"; g.date = Date()
+    let r = RealmMockInterviewRecord()
+    r.id = 3; r.groupId = "G-2"; r.question = "Q"; r.modelAnswer = "A"; r.myAnswer = "B"; r.isSatisfied = false
+    g.records.append(r)
+    try sut.insert(g)
+    
+    try sut.update(RealmMockInterviewGroup.self, forPrimaryKey: "G-2") { group in
+      if let rec = group.records.first(where: { $0.id == 3 }) {
+        rec.isSatisfied.toggle()
+      }
+    }
+    
+    let got = try sut.find(RealmMockInterviewGroup.self, forPrimaryKey: "G-2")
+    #expect(got?.records.first?.isSatisfied == true)
+  }
+  
+  @Test
+  func delete_group() throws {
+    let sut = makeService()
+    let g = RealmMockInterviewGroup(); g.id = "G-3"; g.date = Date()
+    try sut.insert(g)
+    if let grp = try sut.find(RealmMockInterviewGroup.self, forPrimaryKey: "G-3") {
+      try sut.delete(grp)
+    }
+    #expect(try sut.find(RealmMockInterviewGroup.self, forPrimaryKey: "G-3") == nil)
+  }
+}
+
+// MARK: - UserStatus (no PK, single row policy)
+
+@Suite("RealmService.UserStatus")
+struct UserStatusTests {
+  @Test
+  func create_once_and_update_all() throws {
+    let sut = makeService()
+    
+    // 최초 1회 insert
+    let u = RealmUserStatus()
+    u.exp = 0
+    try sut.insert(u)
+    
+    // 전체(사실상 1개)를 updateAll로 수정
+    try sut.updateAll(RealmUserStatus.self, predicate: NSPredicate(value: true)) { obj in
+      obj.exp = 40
+    }
+    
+    let first = try sut.fetch(RealmUserStatus.self).first
+    #expect(first?.exp == 40)
+  }
+  
+  @Test
+  func delete_all_user_status() throws {
+    let sut = makeService()
+    let u = RealmUserStatus(); u.exp = 10
+    try sut.insert(u)
+    try sut.deleteAll(RealmUserStatus.self, predicate: nil)
+    #expect((try sut.fetch(RealmUserStatus.self)).isEmpty)
+  }
+}
+
+// MARK: - LearningData (Category/Concept/QnA PK: Int)
+
+@Suite("RealmService.LearningData")
+struct LearningDataTests {
+  @Test
+  func insert_category_with_child_concept_and_qna() throws {
+    let sut = makeService()
+    
+    // 카테고리
+    let cat = RealmCategory()
+    cat.id = 1
+    cat.category = "iOS"
+    
+    // 컨셉
+    let concept = RealmConcept()
+    concept.id = 101
+    concept.categoryId = 1
+    concept.concept = "Realm"
+    concept.explain = "Mobile database"
+    concept.latestUpdate = Date()
+    concept.isMemory = false
+    
+    // QnA
+    let q = RealmQnA()
+    q.id = 5001
+    q.conceptId = 101
+    q.question = "What is Realm?"
+    q.answer = "A mobile database."
+    q.latestUpdate = Date()
+    
+    concept.qnas.append(q)
+    cat.concepts.append(concept)
+    
+    try sut.insert(cat)
+    
+    // 조회 및 검증
+    let fetchedCat = try sut.find(RealmCategory.self, forPrimaryKey: 1)
+    #expect(fetchedCat?.concepts.count == 1)
+    #expect(fetchedCat?.concepts.first?.qnas.count == 1)
+    #expect(fetchedCat?.concepts.first?.qnas.first?.question == "What is Realm?")
+  }
+  
+  @Test
+  func update_concept_memory_flag_and_delete_qna() throws {
+    let sut = makeService()
+    
+    // 최소 데이터 구성
+    let cat = RealmCategory()
+    cat.id = 2; cat.category = "Swift"
+    let concept = RealmConcept()
+    concept.id = 201; concept.categoryId = 2
+    concept.concept = "ARC"; concept.explain = "Memory"; concept.latestUpdate = Date(); concept.isMemory = false
+    let q = RealmQnA(); q.id = 6001; q.conceptId = 201; q.question = "Q"; q.answer = "A"; q.latestUpdate = Date()
+    concept.qnas.append(q); cat.concepts.append(concept)
+    try sut.insert(cat)
+    
+    // isMemory 토글
+    try sut.update(RealmConcept.self, forPrimaryKey: 201) { c in
+      c.isMemory.toggle()
+    }
+    #expect(try sut.find(RealmConcept.self, forPrimaryKey: 201)?.isMemory == true)
+    
+    // QnA 제거
+    try sut.update(RealmConcept.self, forPrimaryKey: 201) { c in
+      if let idx = c.qnas.firstIndex(where: { $0.id == 6001 }) {
+        c.qnas.remove(at: idx)
+      }
+    }
+    #expect(try sut.find(RealmConcept.self, forPrimaryKey: 201)?.qnas.isEmpty == true)
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #38

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.
Realm을 사용할 때 적용할 Service를 만들었습니다.
-

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.

## 1) 공통 설정

```swift
// App 시작 시 (예: SceneDelegate.makeTabBarController 직전)
let realmService = RealmService()
DIContainer.shared.register(realmService as RealmServiceType)

// 사용부 (어디서든)
let realm: RealmServiceType = DIContainer.shared.resolve()
```

> 주의: 등록 전에 `resolve()`를 호출하면 크래시 납니다. 반드시 **등록 → resolve** 순서로 사용하세요.

---

## 2) 모델별 CRUD 스니펫

> 프로젝트 기준 PK 및 스키마
>
> * **RealmAttendance**: `id: String` (PK)
> * **RealmMockInterviewGroup**: `id: String` (PK)
>
>   * **RealmMockInterviewRecord**: PK 없음 (`id: Int` + `groupId: String` 조합으로 식별)
> * **RealmUserStatus**: PK 없음(단일 레코드 정책)
> * **RealmCategory / RealmConcept / RealmQnA**: 각 `id: Int` (PK)

### A. 출석: `RealmAttendance` (PK: `id`)

```swift
// Create
let domain = Attendance(id: UUID().uuidString, date: Date(), isAttendance: true)
let obj = RealmAttendance(from: domain)
try realm.insert(obj) // PK 중복이면 RealmServiceError.duplicatePrimaryKey

// Read (예: 2025-08 한 달치)
let cal = Calendar(identifier: .gregorian)
let start = cal.date(from: DateComponents(year: 2025, month: 8, day: 1))!
let end = cal.date(byAdding: .month, value: 1, to: start)!
let p = NSPredicate(format: "date >= %@ AND date < %@", start as NSDate, end as NSDate)
let results: Results<RealmAttendance> = try realm.fetch(RealmAttendance.self, predicate: p, sorted: [])

// Update (PK로 조회 후 수정)
try realm.update(RealmAttendance.self, forPrimaryKey: domain.id) { obj in
  obj.isAttendance = false
}

// Delete (단건/일괄)
if let obj = try realm.find(RealmAttendance.self, forPrimaryKey: domain.id) {
  try realm.delete(obj)
}
try realm.deleteAll(RealmAttendance.self, predicate: p)
```

---

### B. 모의면접: `RealmMockInterviewGroup` / `RealmMockInterviewRecord`

```swift
// Create (그룹 생성)
let group = RealmMockInterviewGroup()
group.id = UUID().uuidString
group.date = Date()
try realm.insert(group) // 그룹 PK 중복 시 throw

// Read (최신순)
let groups: Results<RealmMockInterviewGroup> =
  try realm.fetch(RealmMockInterviewGroup.self,
                  predicate: nil,
                  sorted: [SortDescriptor(keyPath: "date", ascending: false)])

// Update (레코드 추가: 그룹 내부 List append, 최대 10개)
try realm.update(RealmMockInterviewGroup.self, forPrimaryKey: group.id) { g in
  guard g.records.count < 10 else { return }
  let r = RealmMockInterviewRecord()
  r.id = 0
  r.groupId = g.id
  r.question = "Q1"
  r.modelAnswer = "A1"
  r.myAnswer = "B1"
  r.isSatisfied = false
  guard g.records.contains(where: { $0.id == r.id }) == false else { return }
  g.records.append(r)
}

// Update (레코드 만족도 토글)
try realm.update(RealmMockInterviewGroup.self, forPrimaryKey: group.id) { g in
  if let rec = g.records.first(where: { $0.id == 3 }) {
    rec.isSatisfied.toggle()
  }
}

// Delete (레코드 제거 / 그룹 제거)
try realm.update(RealmMockInterviewGroup.self, forPrimaryKey: group.id) { g in
  if let idx = g.records.firstIndex(where: { $0.id == 3 }) {
    g.records.remove(at: idx)
  }
}
if let grp = try realm.find(RealmMockInterviewGroup.self, forPrimaryKey: group.id) {
  try realm.delete(grp)
}
```

---

### C. 사용자 경험치: `RealmUserStatus` (PK 없음 · 단일 레코드)

```swift
// Create (최초 1회만)
let status = RealmUserStatus()
status.exp = 0
try realm.insert(status)

// Read
let first: RealmUserStatus? = try realm.fetch(RealmUserStatus.self).first

// Update (predicate 기반 전체/단일 갱신)
try realm.updateAll(RealmUserStatus.self, predicate: NSPredicate(value: true)) { obj in
  obj.exp = 40
}
// 또는: 하나만 가져와서 write 블록에서 수정
if let st = first {
  try realm.write { _ in st.exp = 40 }
}

// Delete (전부 제거)
try realm.deleteAll(RealmUserStatus.self, predicate: nil)
```

---

### D. 학습 데이터: `RealmCategory / RealmConcept / RealmQnA` (각 `id`가 PK)

```swift
// Create (계층 관계 구성 후 카테고리 단위로 insert)
let cat = RealmCategory(); cat.id = 1; cat.category = "iOS"

let concept = RealmConcept()
concept.id = 101
concept.categoryId = 1
concept.concept = "Realm"
concept.explain = "Mobile database"
concept.latestUpdate = Date()
concept.isMemory = false

let qna = RealmQnA()
qna.id = 5001
qna.conceptId = 101
qna.question = "What is Realm?"
qna.answer = "A mobile database."
qna.latestUpdate = Date()

concept.qnas.append(qna)
cat.concepts.append(concept)

try realm.insert(cat) // 중복 PK 있으면 throw

// Read
let fetchedCat = try realm.find(RealmCategory.self, forPrimaryKey: 1)

// Update (예: Concept의 isMemory 토글)
try realm.update(RealmConcept.self, forPrimaryKey: 101) { c in
  c.isMemory.toggle()
}

// Delete (QnA 단건)
if let q = try realm.find(RealmQnA.self, forPrimaryKey: 5001) {
  try realm.delete(q)
}
```

#### ✅ 카테고리 안전 삭제 (자식까지 명시 삭제)

> Realm은 부모 삭제 시 자식이 자동 삭제되지 않습니다.
> QnA → Concept → Category 순으로 **명시 삭제**하세요.

```swift
if let cat = try realm.find(RealmCategory.self, forPrimaryKey: 1) {
  try realm.write { r in
    // 1) 모든 QnA 수집 후 삭제
    let allQnAs: [RealmQnA] = cat.concepts.flatMap { Array($0.qnas) }
    r.delete(allQnAs)
    // 2) Concept 삭제
    r.delete(cat.concepts)
    // 3) Category 삭제
    r.delete(cat)
  }
}
```

---

## 3) 예외/에러 처리 규약

* **중복 PK 삽입**: `RealmServiceError.duplicatePrimaryKey`
* **PK 누락**: `RealmServiceError.missingPrimaryKeyValue`
* **업데이트/일괄 업데이트 대상 없음**: `RealmServiceError.objectNotFound`

```swift
do {
  try realm.insert(obj)
} catch RealmServiceError.duplicatePrimaryKey {
  // TODO: 사용자 피드백 등
} catch {
  // TODO: 공통 에러 처리
}
```

---