### PR TITLE
Feat/#65 학습 결과 화면을 구현했습니다.

### DIFF
--- a/Hello-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Hello-iOS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d2c90c8f1d8c5882bda9b8811bc4e557c714c7a65b561a3b10a5bfc41ddcd3ae",
+  "originHash" : "7412d9d8eaba44e78ea6dfcfb15b46bfaea52f14d49c289ec6823d94da43585f",
   "pins" : [
     {
       "identity" : "fscalendar",
@@ -47,12 +47,30 @@
       }
     },
     {
+      "identity" : "rxrealm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/RxSwiftCommunity/RxRealm",
+      "state" : {
+        "revision" : "267cc8b587a5d5c74b57105050f9838cf20e2541",
+        "version" : "5.1.0"
+      }
+    },
+    {
       "identity" : "rxswift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift",
       "state" : {
         "revision" : "5dd1907d64f0d36f158f61a466bab75067224893",
         "version" : "6.9.0"
+      }
+    },
+    {
+      "identity" : "shuffle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mac-gallagher/Shuffle",
+      "state" : {
+        "branch" : "master",
+        "revision" : "df246b9cd6b8b5e021b23c80706b4a4571785c1b"
       }
     },
     {

--- a/Hello-iOS/App/SceneDelegate.swift
+++ b/Hello-iOS/App/SceneDelegate.swift
@@ -15,10 +15,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
     guard let windowScene = (scene as? UIWindowScene) else { return }
 
-    window = UIWindow(windowScene: windowScene)
-    window?.rootViewController = makeTabBarController()
-    window?.makeKeyAndVisible()
-
     registerObjects()
     window = UIWindow(windowScene: windowScene)
     window?.rootViewController = makeTabBarController()

--- a/Hello-iOS/Presentation/WordBook/WordLearning/LearningResult/LearningResultView.swift
+++ b/Hello-iOS/Presentation/WordBook/WordLearning/LearningResult/LearningResultView.swift
@@ -1,0 +1,7 @@
+//
+//  WordResultView.swift
+//  Hello-iOS
+//
+//  Created by seongjun cho on 8/12/25.
+//
+

--- a/Hello-iOS/Presentation/WordBook/WordLearning/LearningResult/LearningResultView.swift
+++ b/Hello-iOS/Presentation/WordBook/WordLearning/LearningResult/LearningResultView.swift
@@ -5,3 +5,198 @@
 //  Created by seongjun cho on 8/12/25.
 //
 
+import UIKit
+
+import SnapKit
+import Then
+
+final class WordResultView: UIView {
+
+  let resultLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 40, weight: .bold)
+    $0.text = "학습 결과"
+  }
+
+  let ringView =  RingView().then {
+    $0.centerLabel.textColor = .label
+
+    $0.progressColor = .main
+  }
+
+  private let resultView = UIView().then {
+    $0.layer.cornerRadius = 10
+    $0.layer.borderWidth = 2
+    $0.layer.borderColor = UIColor.main.cgColor
+    $0.backgroundColor = .background
+
+    $0.layer.shadowColor = UIColor.black.cgColor
+    $0.layer.shadowOffset = CGSize(width: 0, height: 4)
+    $0.layer.shadowRadius = 3
+    $0.layer.shadowOpacity = 0.35
+  }
+
+  private let correctBorderView = UIView().then {
+    $0.layer.borderColor = UIColor.correct.cgColor
+    $0.layer.borderWidth = 5
+  }
+
+  private let correctLabel = UILabel().then {
+    $0.text = "외웠어요!"
+    $0.font = .systemFont(ofSize: 20, weight: .bold)
+    $0.textColor = .correct
+    $0.textAlignment = .center
+  }
+
+  private let wrongBorderView = UIView().then {
+    $0.layer.borderColor = UIColor.wrong.cgColor
+    $0.layer.borderWidth = 5
+  }
+
+  private let wrongLabel = UILabel().then {
+    $0.text = "다음에"
+    $0.font = .systemFont(ofSize: 20, weight: .bold)
+    $0.textColor = .wrong
+    $0.textAlignment = .center
+  }
+
+  let correctResultLabel = UILabel().then {
+    $0.textAlignment = .center
+    $0.font = .systemFont(ofSize: 28, weight: .bold)
+    $0.textColor = .correct
+    $0.text = "N개"
+  }
+
+  let wrongResultLabel = UILabel().then {
+    $0.textAlignment = .center
+    $0.font = .systemFont(ofSize: 28, weight: .bold)
+    $0.textColor = .wrong
+    $0.text = "N개"
+  }
+
+  let retryButton = UIButton().then {
+    $0.layer.cornerRadius = 20
+    $0.setTitle("다시하기", for: .normal)
+    $0.setTitleColor(.white, for: .normal)
+    $0.backgroundColor = .main
+    $0.layer.masksToBounds = true
+    $0.titleLabel?.font = .systemFont(ofSize: 28, weight: .bold)
+  }
+
+  let backButton = UIButton().then {
+    $0.layer.cornerRadius = 20
+    $0.setTitle("돌아가기", for: .normal)
+    $0.setTitleColor(.main, for: .normal)
+    $0.layer.borderWidth = 1
+    $0.layer.masksToBounds = true
+    $0.titleLabel?.font = .systemFont(ofSize: 28, weight: .bold)
+  }
+
+  let scrollView = UIScrollView().then {
+    $0.showsVerticalScrollIndicator = false
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.backgroundColor = .background
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setupUI() {
+    addSubview(scrollView)
+    scrollView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+
+    let contentView = UIView()
+    scrollView.addSubview(contentView)
+    contentView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+      $0.width.equalToSuperview()
+    }
+
+    contentView.addSubview(resultLabel)
+    contentView.addSubview(ringView)
+    contentView.addSubview(resultView)
+    resultView.addSubview(correctBorderView)
+    correctBorderView.addSubview(correctLabel)
+    resultView.addSubview(wrongBorderView)
+    wrongBorderView.addSubview(wrongLabel)
+    resultView.addSubview(correctResultLabel)
+    resultView.addSubview(wrongResultLabel)
+    contentView.addSubview(retryButton)
+    contentView.addSubview(backButton)
+
+    resultLabel.snp.makeConstraints {
+      $0.top.leading.trailing.equalToSuperview().offset(20)
+      $0.height.equalTo(resultLabel.font.lineHeight)
+    }
+
+    ringView.snp.makeConstraints {
+      $0.top.equalTo(resultLabel.snp.bottom).offset(34)
+      $0.width.height.equalTo(170)
+      $0.centerX.equalToSuperview()
+    }
+
+    resultView.snp.makeConstraints {
+      $0.top.equalTo(ringView.snp.bottom).offset(30)
+      $0.leading.trailing.equalToSuperview().inset(2)
+      $0.height.equalTo(165)
+    }
+
+    correctBorderView.snp.makeConstraints {
+      $0.centerY.equalToSuperview().offset(-40)
+      $0.height.equalTo(42)
+      $0.width.equalTo(114)
+      $0.trailing.equalTo(resultView.snp.centerX)
+    }
+
+    correctLabel.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+
+    wrongBorderView.snp.makeConstraints {
+      $0.centerY.equalToSuperview().offset(40)
+      $0.height.equalTo(42)
+      $0.width.equalTo(114)
+      $0.trailing.equalTo(resultView.snp.centerX)
+    }
+
+    wrongLabel.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+
+    correctResultLabel.snp.makeConstraints {
+      $0.top.bottom.equalTo(correctBorderView)
+      $0.leading.equalTo(correctBorderView.snp.trailing).offset(24)
+    }
+
+    wrongResultLabel.snp.makeConstraints {
+      $0.top.bottom.equalTo(wrongBorderView)
+      $0.leading.equalTo(wrongBorderView.snp.trailing).offset(24)
+    }
+
+    retryButton.snp.makeConstraints {
+      $0.top.equalTo(resultView.snp.bottom).offset(30)
+      $0.height.equalTo(60)
+      $0.leading.trailing.equalToSuperview()
+    }
+
+    backButton.snp.makeConstraints {
+      $0.top.equalTo(retryButton.snp.bottom).offset(20)
+      $0.height.equalTo(60)
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalToSuperview().inset(20)
+    }
+  }
+
+  func configure(correct: Int, wrong: Int) {
+    wrongResultLabel.text = "\(wrong) 개"
+    correctResultLabel.text = "\(correct) 개"
+    ringView.centerLabel.text = String(format: "%.1f", Float(correct) / Float(correct + wrong) * 100)
+    ringView.setProgress(CGFloat(Float(correct) / Float(correct + wrong)), animated: true)
+  }
+}

--- a/Hello-iOS/Presentation/WordBook/WordLearning/WordLearningView.swift
+++ b/Hello-iOS/Presentation/WordBook/WordLearning/WordLearningView.swift
@@ -18,6 +18,10 @@ class WordLearningView: UIView {
     $0.isHidden = true
   }
 
+  let reulstView = WordResultView().then {
+    $0.isHidden = true
+  }
+
   override init(frame: CGRect) {
     super.init(frame: frame)
     self.backgroundColor = .background
@@ -31,6 +35,7 @@ class WordLearningView: UIView {
   private func setupUI() {
     addSubview(cardStack)
     addSubview(addContentView)
+    addSubview(reulstView)
 
     cardStack.snp.makeConstraints {
       $0.top.equalTo(self.safeAreaLayoutGuide).offset(45)
@@ -43,6 +48,12 @@ class WordLearningView: UIView {
       $0.centerX.equalToSuperview()
       $0.width.equalToSuperview().multipliedBy(0.8)
       $0.height.equalTo(addContentView.snp.width).multipliedBy(1.5)
+    }
+
+    reulstView.snp.makeConstraints {
+      $0.top.equalTo(self.safeAreaLayoutGuide)
+      $0.leading.trailing.equalTo(self.safeAreaLayoutGuide).inset(30)
+      $0.bottom.equalTo(self.safeAreaLayoutGuide)
     }
   }
 

--- a/Hello-iOS/Presentation/WordBook/WordLearning/WordLearningViewController.swift
+++ b/Hello-iOS/Presentation/WordBook/WordLearning/WordLearningViewController.swift
@@ -47,8 +47,33 @@ class WordLearningViewController: BaseViewController<WordLearningReactor> {
   }
 
   override func bind(reactor: WordLearningReactor) {
-    wordLearningView.addContentView.addButton.rx.tap.subscribe(onNext: { [weak self] in
+    wordLearningView.addContentView.addButton.rx
+      .tap
+      .subscribe(onNext: { [weak self] in
       self?.didTapAddContentButton()
+    }).disposed(by: disposeBag)
+
+    wordLearningView.reulstView.backButton.rx
+      .tap
+      .subscribe(onNext: { [weak self] in
+        self?.navigationController?.popViewController(animated: true)
+    }).disposed(by: disposeBag)
+
+    wordLearningView.reulstView.retryButton.rx
+      .tap
+      .subscribe(onNext: { [weak self] in
+        self?.wordLearningView.reulstView.isHidden = true
+        for _ in 0..<reactor.currentState.concepts.count {
+          self?.wordLearningView.cardStack.undoLastSwipe(animated: false)
+        }
+    }).disposed(by: disposeBag)
+
+    reactor.state.map { $0.concepts }.subscribe(onNext: { [weak self] concepts in
+      self?.wordLearningView
+        .reulstView
+        .configure(correct: concepts.filter { $0.isMemory }.count,
+                   wrong: concepts.filter { $0.isMemory == false }.count
+        )
     }).disposed(by: disposeBag)
   }
 }
@@ -82,6 +107,7 @@ extension WordLearningViewController: SwipeCardStackDataSource, SwipeCardStackDe
 
   func didSwipeAllCards(_ cardStack: SwipeCardStack) {
     // TODO: 결과화면 isHidden false
+    wordLearningView.reulstView.isHidden = false
   }
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #65

## 🛠️ 작업 내용
> 변경한 핵심 내용을 간단히 요약해주세요.

- 학습 결과 화면 UI 를 구현했습니다.
- 학습 결과 비즈니스 로직을 구현했습니다.

## ✅ 체크리스트
- [x] **base 브랜치를 develop으로 설정했나요?**
- [x] **작업 전 develop 브랜치를 Pull 받았나요?**
- [x] **PR의 라벨을 설정했나요?**
- [x] **assignee를 설정했나요?**
- [x] **reviewers를 설정했나요?**
- [x] **변경 사항에 대한 테스트를 진행했나요?**

## 📸 스크린샷
> UI 관련 변경이 있다면 스크린샷을 첨부해주세요.

<img width="300" alt="simulator_screenshot_2EB20400-B3BC-4E8A-8F69-43CDA5C71DB3" src="https://github.com/user-attachments/assets/665a488b-1685-4437-8a68-cd9c39f2c770" />

## 💬 기타 참고사항
> 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 여기에 적어주세요.
